### PR TITLE
Enhance fonts for a cooler homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,9 +4,15 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>フェニックスのホームページ</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&family=Noto+Sans+JP:wght@400;700&display=swap"
+    rel="stylesheet"
+  />
   <style>
     body{
-      font-family:sans-serif;
+      font-family:'Noto Sans JP', sans-serif;
       text-align:center;
       padding-top:20vh;
       margin:0;
@@ -15,6 +21,7 @@
       animation:bg-rainbow 20s linear infinite;
     }
     h1{
+      font-family:'Orbitron', sans-serif;
       font-size:3em;
       background:linear-gradient(90deg, red, orange, yellow, green, aqua, blue, purple);
       background-size:400% 100%;


### PR DESCRIPTION
## Summary
- load Orbitron and Noto Sans JP from Google Fonts
- use Noto Sans JP for the body
- use Orbitron for the main heading

## Testing
- `python -m py_compile suzacquegame.py`

------
https://chatgpt.com/codex/tasks/task_e_683f9c8627fc832d98ddffa640fd6aa2